### PR TITLE
Implement user module with basic auth

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,26 @@
-import { Controller, Post, Req, UseGuards } from "@nestjs/common";
+import { Body, Controller, Post, Req, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Request } from "express";
 import { AuthService } from "./auth.service";
+import { CreateUserDto } from "../users/dto/create-user.dto";
 
 @Controller("auth")
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  @Post("register")
+  register(@Body() dto: CreateUserDto) {
+    return this.authService.register(dto);
+  }
+
+  @Post("login")
+  async login(@Body() body: { email: string; password: string }) {
+    const user = await this.authService.validateUser(body.email, body.password);
+    if (!user) {
+      return { error: "Invalid credentials" };
+    }
+    return this.authService.login(user);
+  }
 
   @UseGuards(AuthGuard("jwt"))
   @Post("profile")

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
-import { PassportModule } from '@nestjs/passport';
-import { AuthService } from './auth.service';
-import { JwtStrategy } from './jwt.strategy';
-import { AuthController } from './auth.controller';
+import { Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { PassportModule } from "@nestjs/passport";
+import { UsersModule } from "../users/users.module";
+import { AuthService } from "./auth.service";
+import { JwtStrategy } from "./jwt.strategy";
+import { AuthController } from "./auth.controller";
 
 @Module({
   imports: [
@@ -11,9 +12,10 @@ import { AuthController } from './auth.controller';
     JwtModule.registerAsync({
       useFactory: () => ({
         secret: process.env.JWT_SECRET,
-        signOptions: { expiresIn: '1h' },
+        signOptions: { expiresIn: "1h" },
       }),
     }),
+    UsersModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy],

--- a/src/auth/jwt-user.interface.ts
+++ b/src/auth/jwt-user.interface.ts
@@ -1,0 +1,4 @@
+export interface JwtUser {
+  userId: number;
+  username: string;
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
+import { JwtUser } from "./jwt-user.interface";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -12,7 +13,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: { sub: number; username: string }) {
+  validate(payload: { sub: number; username: string }): JwtUser {
     return { userId: payload.sub, username: payload.username };
   }
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,5 @@
+export class CreateUserDto {
+  fullName!: string;
+  email!: string;
+  password!: string;
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateUserDto {
+  fullName?: string;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, Unique } from "typeorm";
+
+@Entity()
+@Unique(["email"])
+export class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  fullName!: string;
+
+  @Column()
+  email!: string;
+
+  @Column()
+  password!: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  Body,
+  UseGuards,
+  Req,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { Request } from "express";
+import { UsersService } from "./users.service";
+import { UpdateUserDto } from "./dto/update-user.dto";
+import { JwtUser } from "../auth/jwt-user.interface";
+
+@Controller("users")
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @UseGuards(AuthGuard("jwt"))
+  @Get("me")
+  async getMe(@Req() req: Request & { user: JwtUser }) {
+    return this.usersService.findById(req.user.userId);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Patch("me")
+  async updateMe(
+    @Req() req: Request & { user: JwtUser },
+    @Body() dto: UpdateUserDto,
+  ) {
+    return this.usersService.update(req.user.userId, dto);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Delete("me")
+  async deleteMe(@Req() req: Request & { user: JwtUser }) {
+    await this.usersService.remove(req.user.userId);
+    return { deleted: true };
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,4 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { UsersService } from "./users.service";
+import { UsersController } from "./users.controller";
+import { User } from "./entities/user.entity";
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import * as bcrypt from "bcrypt";
+import { User } from "./entities/user.entity";
+import { CreateUserDto } from "./dto/create-user.dto";
+import { UpdateUserDto } from "./dto/update-user.dto";
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async create(dto: CreateUserDto): Promise<User> {
+    const hashedPassword = await bcrypt.hash(dto.password, 10);
+    const user = this.usersRepository.create({
+      email: dto.email,
+      fullName: dto.fullName,
+      password: hashedPassword,
+    });
+    return this.usersRepository.save(user);
+  }
+
+  findByEmail(email: string): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { email } });
+  }
+
+  findById(id: number): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { id } });
+  }
+
+  async update(id: number, dto: UpdateUserDto): Promise<User> {
+    const user = await this.findById(id);
+    if (!user) throw new Error("User not found");
+    if (dto.fullName !== undefined) {
+      user.fullName = dto.fullName;
+    }
+    return this.usersRepository.save(user);
+  }
+
+  async remove(id: number): Promise<void> {
+    await this.usersRepository.delete(id);
+  }
+}


### PR DESCRIPTION
## Summary
- implement User entity and DTOs
- add UsersService and UsersController for profile CRUD
- expand AuthService and AuthController for registration and login
- wire UsersModule and update JWT strategy

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c3e9b97608324b5cc9812dda402c4